### PR TITLE
Add unit declarator to module declarations

### DIFF
--- a/lib/Lingua/EN/Syllable.pm
+++ b/lib/Lingua/EN/Syllable.pm
@@ -11,7 +11,7 @@
 
 =end comment
 
-module Lingua::EN::Syllable;
+unit module Lingua::EN::Syllable;
 
 my @SubSyl =
     / 'cial' /,


### PR DESCRIPTION
As of Rakudo 2015.05, the `unit` declarator is required before using
`module`, `class` or `grammar` declarations (unless it uses a block).  Code
still using the old blockless semicolon form will throw a warning. This
commit stops the warning from appearing in the new Rakudo.
