### PR TITLE
Use SPDX identifier in license field of META6.json

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -1,12 +1,15 @@
 {
-    "perl" : "6.*",
-    "name" : "Lingua::EN::Syllable",
-    "version" : "*",
-    "author" : "Will “Coke” Coleda",
-    "description" : "Guess the number of syllables in an English word",
-    "provides" : {
-        "Lingua::EN::Syllable": "lib/Lingua/EN/Syllable.pm"
-    },
-    "depends" : [],
-    "source-url" : "git://github.com/coke/p6-lingua-en-syllable.git"
+  "name": "Lingua::EN::Syllable",
+  "source-url": "git://github.com/coke/p6-lingua-en-syllable.git",
+  "perl": "6.*",
+  "author": "Will “Coke” Coleda",
+  "depends": [
+    
+  ],
+  "license": "Artistic-2.0",
+  "provides": {
+    "Lingua::EN::Syllable": "lib/Lingua/EN/Syllable.pm"
+  },
+  "version": "*",
+  "description": "Guess the number of syllables in an English word"
 }


### PR DESCRIPTION
Use the standardized identifier for the license field.
For more details see https://design.perl6.org/S22.html#license